### PR TITLE
Added ability to send arbitrary events to queue

### DIFF
--- a/powermate.py
+++ b/powermate.py
@@ -254,6 +254,9 @@ class AsyncFileEventDispatcher(object):
     thread.start()
     self.__threads.append(thread)
 
+  def send_event(self, event):
+    self.__source.send(event)
+
   def run(self):
     self.__source.watch()
 


### PR DESCRIPTION
This library was perfect for my needs except LedEvents could only be sent when returned from the EventHandler. I wanted to also trigger them elsewhere.

This adds a send_event method to AsyncFileEventDispatcher. I wasn't sure exactly what level it would best be implemented at, but that's closest to the source. Works perfectly for my needs, allows setting the LED status without touching the knob.

Let me know if there was a better/more pythonic way of doing this, I'm a bit rusty.